### PR TITLE
Fix compiling with clang 3.5

### DIFF
--- a/Plugins/ExtraCamWindow/Source/ExtraCamWindow/ExtraCamWindowActor.cpp
+++ b/Plugins/ExtraCamWindow/Source/ExtraCamWindow/ExtraCamWindowActor.cpp
@@ -91,7 +91,7 @@ void AExtraCamWindowActor::BeginPlay()
 	// the window and some stuff gets initialized by ticking slate, otherwise we get a thread-related crash in packaged builds..
 	FSlateApplication::Get().Tick();
 
-	SceneViewport->SetOnSceneViewportResizeDel(FOnSceneViewportResize::CreateLambda([this](auto newViewportSize)
+	SceneViewport->SetOnSceneViewportResizeDel(FOnSceneViewportResize::CreateLambda([this](FVector2D newViewportSize)
 	{
 		if (LockResToMainWindow == false)
 			return;


### PR DESCRIPTION
Fix compiling with clang 3.5 (default for 4.12 on Linux)
error: 'auto' not allowed in lambda
